### PR TITLE
Added unattendend updates for security

### DIFF
--- a/14.04/Dockerfile
+++ b/14.04/Dockerfile
@@ -79,6 +79,7 @@ RUN apt-get -q update && \
 	wget \
 	whiptail \
 	software-properties-common \
+    unattended-upgrades \
     && apt-get clean
 
 

--- a/14.04/overlay/etc/apt/apt.conf.d/10periodic
+++ b/14.04/overlay/etc/apt/apt.conf.d/10periodic
@@ -1,0 +1,4 @@
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";

--- a/14.04/overlay/etc/apt/apt.conf.d/50unattended-upgrades
+++ b/14.04/overlay/etc/apt/apt.conf.d/50unattended-upgrades
@@ -5,3 +5,4 @@ Unattended-Upgrade::Package-Blacklist {
     "xnbd-client";
     "nbd-client";
 };
+Unattended-Upgrade::Automatic-Reboot "false";

--- a/14.04/overlay/etc/apt/apt.conf.d/50unattended-upgrades
+++ b/14.04/overlay/etc/apt/apt.conf.d/50unattended-upgrades
@@ -1,0 +1,7 @@
+Unattended-Upgrade::Allowed-Origins {
+    "Ubuntu trusty-security";
+};
+Unattended-Upgrade::Package-Blacklist {
+    "xnbd-client";
+    "nbd-client";
+};

--- a/15.10/Dockerfile
+++ b/15.10/Dockerfile
@@ -80,6 +80,7 @@ RUN apt-get -q update && \
 	vim \
 	wget \
 	whiptail \
+    unattended-upgrades \
     && apt-get clean
 
 

--- a/15.10/overlay/etc/apt/apt.conf.d/10periodic
+++ b/15.10/overlay/etc/apt/apt.conf.d/10periodic
@@ -1,0 +1,4 @@
+APT::Periodic::Update-Package-Lists "1";
+APT::Periodic::Download-Upgradeable-Packages "1";
+APT::Periodic::AutocleanInterval "7";
+APT::Periodic::Unattended-Upgrade "1";

--- a/15.10/overlay/etc/apt/apt.conf.d/50unattended-upgrades
+++ b/15.10/overlay/etc/apt/apt.conf.d/50unattended-upgrades
@@ -5,3 +5,4 @@ Unattended-Upgrade::Package-Blacklist {
     "xnbd-client";
     "nbd-client";
 };
+Unattended-Upgrade::Automatic-Reboot "false";

--- a/15.10/overlay/etc/apt/apt.conf.d/50unattended-upgrades
+++ b/15.10/overlay/etc/apt/apt.conf.d/50unattended-upgrades
@@ -1,0 +1,7 @@
+Unattended-Upgrade::Allowed-Origins {
+    "Ubuntu wily-security";
+};
+Unattended-Upgrade::Package-Blacklist {
+    "xnbd-client";
+    "nbd-client";
+};


### PR DESCRIPTION
The glibc variability that was discovered made me think that automatic updates for security patches might be handy, you don't want ssh in all your C1s to fix this in the future. 