### PR TITLE
Change readme to reflect actual available tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Available tags
 
 - precise (12.04)
 - trusty (14.04, lts)
-- vivid (15.04, latest)
+- wily (15.10, latest)
 
 ---
 


### PR DESCRIPTION
I've changed the readme to reflect the removal of 15.04 and it's replacement with 15.10.