### PR TITLE
Fix reboot Xenial

### DIFF
--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -129,5 +129,8 @@ RUN chown root:syslog /var/log \
  && chmod 755 /etc/default
 
 
+# HotFix Reboot
+RUN systemctl mask networking
+
 # Clean rootfs from image-builder
 RUN /usr/local/sbin/scw-builder-leave


### PR DESCRIPTION
Without this fix, we can't reboot because the networking service which comes from the package `ifupdown`, closes the network connection during the reboot.