### PR TITLE
temporarily fix haveged service

### DIFF
--- a/16.10/overlay/etc/systemd/system/haveged.service
+++ b/16.10/overlay/etc/systemd/system/haveged.service
@@ -1,0 +1,1 @@
+../../../../../17.04/overlay/etc/systemd/system/haveged.service

--- a/17.04/overlay/etc/systemd/system/haveged.service
+++ b/17.04/overlay/etc/systemd/system/haveged.service
@@ -1,0 +1,23 @@
+[Unit]
+Description=Entropy daemon using the HAVEGE algorithm
+Documentation=man:haveged(8) http://www.issihosts.com/haveged/
+DefaultDependencies=no
+ConditionVirtualization=!container
+After=apparmor.service systemd-random-seed.service systemd-tmpfiles-setup.service
+Before=sysinit.target shutdown.target
+
+[Service]
+EnvironmentFile=-/etc/default/haveged
+ExecStart=/usr/sbin/haveged --Foreground --verbose=1 $DAEMON_ARGS
+SuccessExitStatus=143
+SecureBits=noroot-locked
+NoNewPrivileges=yes
+CapabilityBoundingSet=CAP_SYS_ADMIN
+PrivateTmp=yes
+PrivateDevices=yes
+PrivateNetwork=yes
+ProtectSystem=full
+ProtectHome=yes
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Haveged doesn't start properly because of a race condition with the `systemd-tmpfiles-setup` service.
This is a temporary fix that should be removed once fixed upstream.