### PR TITLE
Bionic: Remove Ubuntu landscape motd

### DIFF
--- a/18.04/Dockerfile
+++ b/18.04/Dockerfile
@@ -55,6 +55,8 @@ RUN systemctl preset --preset-mode=full $(cat /etc/systemd/system-preset/scw*.pr
 # Remove dbus machine-id
 RUN rm /var/lib/dbus/machine-id
 
+# Remove the Ubuntu landscape motd as we duplicate this
+RUN rm /etc/update-motd.d/50-landscape-sysinfo
 
 # Clean rootfs from image-builder
 RUN /usr/local/sbin/scw-builder-leave


### PR DESCRIPTION
Bionic hosts have a motd banner provided by `landscape-common` which conflicts with the scaleway motd banner.

Remove the symbolic link created in `/etc/update-motd.d/` by the `landscape-common` package so only the scaleway motd is printed on login.

Signed-off-by: Hal Martin <hmartin@online.net>