### PR TITLE
Add command-not-found to the image

### DIFF
--- a/16.04/Dockerfile
+++ b/16.04/Dockerfile
@@ -40,6 +40,7 @@ RUN apt-get -q update && \
 	bc \
 	ca-certificates \
 	cron \
+	command-not-found \
 	curl \
 	dbus \
 	dstat \


### PR DESCRIPTION
Normally I am against bloatware, but since it's a recommended package for
ubuntu-standard and we are shipping it in Bionic ¯\_(ツ)_/¯

Signed-off-by: Hal Martin <hmartin@online.net>